### PR TITLE
Arrange (bring forward, etc.) tweaks

### DIFF
--- a/src/Editor/Panels/Toolbox/CanvasActions/CanvasActions.jsx
+++ b/src/Editor/Panels/Toolbox/CanvasActions/CanvasActions.jsx
@@ -22,10 +22,10 @@ class CanvasActions extends Component {
   renderActions = () => {
     return (
       <div className='actions-container'>
-        {this.renderActionButton(this.props.editorActions.sendBackward)}
         {this.renderActionButton(this.props.editorActions.sendToBack)}
-        {this.renderActionButton(this.props.editorActions.sendToFront)}
+        {this.renderActionButton(this.props.editorActions.sendBackward)}
         {this.renderActionButton(this.props.editorActions.sendForward)}
+        {this.renderActionButton(this.props.editorActions.sendToFront)}
         <ToolboxBreak className="toolbox-item"/>
         {this.renderActionButton(this.props.editorActions.flipHorizontal)}
         {this.renderActionButton(this.props.editorActions.flipVertical)}

--- a/src/Editor/hotKeyMap.js
+++ b/src/Editor/hotKeyMap.js
@@ -108,7 +108,7 @@ class HotKeyInterface extends Object {
       'move-playhead-forwards': this.editor.movePlayheadForwards,
       'move-playhead-backwards': this.editor.movePlayheadBackwards,
       'select-all': this.editor.selectAll,
-      'bring-to-front': this.editor.bringSelectionToFront,
+      'bring-to-front': this.editor.sendSelectionToFront,
       'send-to-back': this.editor.sendSelectionToBack,
       'move-forwards': this.editor.moveSelectionForwards,
       'move-backwards': this.editor.moveSelectionBackwards,


### PR DESCRIPTION
* Arrange the icons spatially (send to back, send backward, bring forward, bring to front)
   * I did this since I found the old order confusing, but it's not really a must-have.
* Fix Bring Forward (Control/Cmd+Shift+Up) shortcut (it threw an error before)