### PR TITLE
Update project converter links

### DIFF
--- a/public/project-converter/index.html
+++ b/public/project-converter/index.html
@@ -61,8 +61,8 @@
         <div>
         
         <div id="page-subtitle">
-            <h3>Upload your 0.15.2 project here to convert it to the <a href="alpha.wickeditor.com">Wick Editor alpha.</a></h3>
-            <h6>Please report converter bugs on our forum at <a href="forum.wickeditor.com">forum.wickeditor.com</a></h6>
+            <h3>Upload your 0.15.2 project here to convert it to the <a href="//editor.wickeditor.com">new Wick Editor.</a></h3>
+            <h6>Please report converter bugs on our forum at <a href="//forum.wickeditor.com">forum.wickeditor.com</a></h6>
         </div>
 
         <div id="input-container">


### PR DESCRIPTION
This PR updates the links of two <a> tags, as well as updating part of some text.

"alpha.wickeditor.com" > "//editor.wickeditor.com"

"forum.wickeditor.com" > "//forum.wickeditor.com"

also changed "Wick Editor alpha" to "new Wick Editor"

## Why?

I changed the links because of this:
![image](https://user-images.githubusercontent.com/29169102/67154906-9a295f00-f2d1-11e9-8178-d3eae384e207.png)

I also changed "Wick Editor alpha" to "new Wick Editor" because it seems 1.0 isn't in alpha anymore