### PR TITLE
Add ErrorBoundary to app

### DIFF
--- a/src/Editor/Editor.jsx
+++ b/src/Editor/Editor.jsx
@@ -50,6 +50,7 @@ import CanvasTransforms from './Panels/CanvasTransforms/CanvasTransforms';
 import Toolbox from './Panels/Toolbox/Toolbox';
 import AssetLibrary from './Panels/AssetLibrary/AssetLibrary';
 import PopOutCodeEditor from './PopOuts/PopOutCodeEditor/PopOutCodeEditor';
+import ErrorBoundary from './Util/ErrorBoundary';
 
 class Editor extends EditorCore {
   constructor () {
@@ -670,231 +671,236 @@ class Editor extends EditorCore {
     window.editor = this;
 
     return (
-      <div>
+      <ErrorBoundary
+        fallback={() => <div>Oops! Something broke</div>}
+        processError={(error, errorInfo)=> null /* save project here */ }
+        >
         <div>
-          <ToastContainer
-           transition={Slide}
-            position="top-right"
-            autoClose={5000}
-            hideProgressBar={false}
-            newestOnTop={false}
-            closeOnClick
-            rtl={false}
-            pauseOnVisibilityChange
-            draggable
-            pauseOnHover
-          />
-            <GlobalHotKeys
-              allowChanges={true}
-              keyMap={this.getKeyMap()}
-              handlers={this.getKeyHandlers()}/>
-              <div id="editor">
-                <input
-                  type='file'
-                  accept={window.Wick.FileAsset.getValidExtensions().join(', ')}
-                  style={{display: 'none'}}
-                  ref={this.importAssetRef}
-                  onChange={this.handleAssetFileImport}
-                />
-                <input
-                  type='file'
-                  accept='.zip, .wick'
-                  style={{display: 'none'}}
-                  ref={this.openFileRef}
-                  onChange={this.handleWickFileLoad}
-                />
-                <div id="menu-bar-container">
-                  <ModalHandler
-                    activeModalName={this.state.activeModalName}
-                    openModal={this.openModal}
-                    closeActiveModal={this.closeActiveModal}
-                    queueModal={this.queueModal}
-                    project={this.project}
-                    createClipFromSelection={this.createClipFromSelection}
-                    createButtonFromSelection={this.createButtonFromSelection}
-                    updateProjectSettings={this.updateProjectSettings}
-                    exportProjectAsGif={this.exportProjectAsAnimatedGIF}
-                    exportProjectAsVideo={this.exportProjectAsVideo}
-                    exportProjectAsStandaloneZip={this.exportProjectAsStandaloneZip}
-                    warningModalInfo={this.state.warningModalInfo}
-                    loadAutosavedProject={this.loadAutosavedProject}
-                    clearAutoSavedProject={this.clearAutoSavedProject}
-                    renderProgress={this.state.renderProgress}
-                    renderStatusMessage={this.state.renderStatusMessage}
-                    renderType={this.state.renderType}
-                    addCustomHotKeys={this.addCustomHotKeys}
-                    resetCustomHotKeys={this.resetCustomHotKeys}
-                    customHotKeys={this.state.customHotKeys}
-                    keyMap={this.getKeyMap()}
+          <div>
+            <ToastContainer
+            transition={Slide}
+              position="top-right"
+              autoClose={5000}
+              hideProgressBar={false}
+              newestOnTop={false}
+              closeOnClick
+              rtl={false}
+              pauseOnVisibilityChange
+              draggable
+              pauseOnHover
+            />
+              <GlobalHotKeys
+                allowChanges={true}
+                keyMap={this.getKeyMap()}
+                handlers={this.getKeyHandlers()}/>
+                <div id="editor">
+                  <input
+                    type='file'
+                    accept={window.Wick.FileAsset.getValidExtensions().join(', ')}
+                    style={{display: 'none'}}
+                    ref={this.importAssetRef}
+                    onChange={this.handleAssetFileImport}
                   />
-                  {/* Header */}
-                  <DockedPanel showOverlay={this.state.previewPlaying}>
-                    <MenuBar
+                  <input
+                    type='file'
+                    accept='.zip, .wick'
+                    style={{display: 'none'}}
+                    ref={this.openFileRef}
+                    onChange={this.handleWickFileLoad}
+                  />
+                  <div id="menu-bar-container">
+                    <ModalHandler
+                      activeModalName={this.state.activeModalName}
                       openModal={this.openModal}
-                      projectName={this.project.name}
-                      openProjectFileDialog={this.openProjectFileDialog}
-                      openNewProjectConfirmation={this.openNewProjectConfirmation}
-                      exportProjectAsWickFile={this.exportProjectAsWickFile}
-                      importProjectAsWickFile={this.importProjectAsWickFile}
-                      toast={this.toast}
-                      openExportOptions={() => {this.openModal('ExportOptions')}}
+                      closeActiveModal={this.closeActiveModal}
+                      queueModal={this.queueModal}
+                      project={this.project}
+                      createClipFromSelection={this.createClipFromSelection}
+                      createButtonFromSelection={this.createButtonFromSelection}
+                      updateProjectSettings={this.updateProjectSettings}
+                      exportProjectAsGif={this.exportProjectAsAnimatedGIF}
+                      exportProjectAsVideo={this.exportProjectAsVideo}
+                      exportProjectAsStandaloneZip={this.exportProjectAsStandaloneZip}
+                      warningModalInfo={this.state.warningModalInfo}
+                      loadAutosavedProject={this.loadAutosavedProject}
+                      clearAutoSavedProject={this.clearAutoSavedProject}
+                      renderProgress={this.state.renderProgress}
+                      renderStatusMessage={this.state.renderStatusMessage}
+                      renderType={this.state.renderType}
+                      addCustomHotKeys={this.addCustomHotKeys}
+                      resetCustomHotKeys={this.resetCustomHotKeys}
+                      customHotKeys={this.state.customHotKeys}
+                      keyMap={this.getKeyMap()}
                     />
-                  </DockedPanel>
-                </div>
-                <div id="editor-body">
-                  <div id="flexible-container">
-                    {/*App*/}
-                    <ReflexContainer windowResizeAware={true} orientation="vertical">
-                      {/* Middle Panel */}
-                      <ReflexElement {...this.resizeProps}>
-                        {/*Toolbox*/}
-                        <div id="toolbox-container">
-                          <DockedPanel showOverlay={this.state.previewPlaying}>
-                            <Toolbox
-                              project={this.state.project}
-                              getActiveToolName={() => this.getActiveTool().name}
-                              activeToolName={this.getActiveTool().name}
-                              setActiveTool={this.setActiveTool}
-                              getToolSetting={this.getToolSetting}
-                              setToolSetting={this.setToolSetting}
-                              previewPlaying={this.state.previewPlaying}
-                              editorActions={this.actionMapInterface.editorActions}
-                              getToolSettingRestrictions={this.getToolSettingRestrictions}
-                              showCanvasActions={this.state.showCanvasActions}
-                              toggleCanvasActions={this.toggleCanvasActions}
-                            />
-                          </DockedPanel>
-                        </div>
-                        <div id="editor-canvas-timeline-panel">
+                    {/* Header */}
+                    <DockedPanel showOverlay={this.state.previewPlaying}>
+                      <MenuBar
+                        openModal={this.openModal}
+                        projectName={this.project.name}
+                        openProjectFileDialog={this.openProjectFileDialog}
+                        openNewProjectConfirmation={this.openNewProjectConfirmation}
+                        exportProjectAsWickFile={this.exportProjectAsWickFile}
+                        importProjectAsWickFile={this.importProjectAsWickFile}
+                        toast={this.toast}
+                        openExportOptions={() => {this.openModal('ExportOptions')}}
+                      />
+                    </DockedPanel>
+                  </div>
+                  <div id="editor-body">
+                    <div id="flexible-container">
+                      {/*App*/}
+                      <ReflexContainer windowResizeAware={true} orientation="vertical">
+                        {/* Middle Panel */}
+                        <ReflexElement {...this.resizeProps}>
+                          {/*Toolbox*/}
+                          <div id="toolbox-container">
+                            <DockedPanel showOverlay={this.state.previewPlaying}>
+                              <Toolbox
+                                project={this.state.project}
+                                getActiveToolName={() => this.getActiveTool().name}
+                                activeToolName={this.getActiveTool().name}
+                                setActiveTool={this.setActiveTool}
+                                getToolSetting={this.getToolSetting}
+                                setToolSetting={this.setToolSetting}
+                                previewPlaying={this.state.previewPlaying}
+                                editorActions={this.actionMapInterface.editorActions}
+                                getToolSettingRestrictions={this.getToolSettingRestrictions}
+                                showCanvasActions={this.state.showCanvasActions}
+                                toggleCanvasActions={this.toggleCanvasActions}
+                              />
+                            </DockedPanel>
+                          </div>
+                          <div id="editor-canvas-timeline-panel">
+                            <ReflexContainer windowResizeAware={true} orientation="horizontal">
+                              {/*Canvas*/}
+                              <ReflexElement {...this.resizeProps}>
+                                <DockedPanel>
+                                  <Canvas
+                                    project={this.project}
+                                    projectDidChange={this.projectDidChange}
+                                    projectData={this.state.project}
+                                    paper={this.paper}
+                                    previewPlaying={this.state.previewPlaying}
+                                    createImageFromAsset={this.createImageFromAsset}
+                                    toast={this.toast}
+                                    onRef={ref => this.canvasComponent = ref}
+                                  />
+                                  <CanvasTransforms
+                                    onionSkinEnabled={this.project.onionSkinEnabled}
+                                    toggleOnionSkin={this.toggleOnionSkin}
+                                    zoomIn={this.zoomIn}
+                                    zoomOut={this.zoomOut}
+                                    recenterCanvas={this.recenterCanvas}
+                                    activeToolName={this.getActiveTool().name}
+                                    setActiveTool={this.setActiveTool}
+                                    previewPlaying={this.state.previewPlaying}
+                                    togglePreviewPlaying={this.togglePreviewPlaying}
+                                  />
+                                </DockedPanel>
+                              </ReflexElement>
+                              <ReflexSplitter {...this.resizeProps}/>
+                              {/*Timeline*/}
+                              <ReflexElement
+                                minSize={100}
+                                size={this.state.timelineSize}
+                                onResize={this.resizeProps.onResize}
+                                onStopResize={this.resizeProps.onStopTimelineResize}>
+                                <DockedPanel  showOverlay={this.state.previewPlaying}>
+                                  <Timeline
+                                    project={this.project}
+                                    projectDidChange={this.projectDidChange}
+                                    projectData={this.state.project}
+                                    getSelectedTimelineObjects={this.getSelectedTimelineObjects}
+                                    setOnionSkinOptions={this.setOnionSkinOptions}
+                                    getOnionSkinOptions={this.getOnionSkinOptions}
+                                    setFocusObject={this.setFocusObject}
+                                    addTweenKeyframe={this.addTweenKeyframe}
+                                    onRef={ref => this.timelineComponent = ref}
+                                    dragSoundOntoTimeline={this.dragSoundOntoTimeline}
+                                  />
+                                </DockedPanel>
+                              </ReflexElement>
+                            </ReflexContainer>
+                          </div>
+                        </ReflexElement>
+
+                        <ReflexSplitter {...this.resizeProps}/>
+
+                        {/* Right Sidebar */}
+                        <ReflexElement
+                          size={250}
+                          maxSize={300} minSize={200}
+                          onResize={this.resizeProps.onResize}
+                          onStopResize={this.resizeProps.onStopInspectorResize}>
                           <ReflexContainer windowResizeAware={true} orientation="horizontal">
-                            {/*Canvas*/}
+                            {/* Inspector */}
                             <ReflexElement {...this.resizeProps}>
-                              <DockedPanel>
-                                <Canvas
+                              <DockedPanel showOverlay={this.state.previewPlaying}>
+                                <Inspector
+                                  getToolSetting={this.getToolSetting}
+                                  setToolSetting={this.setToolSetting}
+                                  getSelectionType={this.getSelectionType}
+                                  getAllSoundAssets={this.getAllSoundAssets}
+                                  getAllSelectionAttributes={this.getAllSelectionAttributes}
+                                  setSelectionAttribute={this.setSelectionAttribute}
+                                  editorActions={this.actionMapInterface.editorActions}
+                                  selectionIsScriptable={this.selectionIsScriptable}
+                                  script={this.getSelectedObjectScript()}
+                                  scriptInfoInterface={this.scriptInfoInterface}
+                                  deleteScript={this.deleteScript}
+                                  editScript={this.editScript}
+                                  fontInfoInterface={this.fontInfoInterface}
                                   project={this.project}
-                                  projectDidChange={this.projectDidChange}
-                                  projectData={this.state.project}
-                                  paper={this.paper}
-                                  previewPlaying={this.state.previewPlaying}
-                                  createImageFromAsset={this.createImageFromAsset}
-                                  toast={this.toast}
-                                  onRef={ref => this.canvasComponent = ref}
-                                />
-                                <CanvasTransforms
-                                  onionSkinEnabled={this.project.onionSkinEnabled}
-                                  toggleOnionSkin={this.toggleOnionSkin}
-                                  zoomIn={this.zoomIn}
-                                  zoomOut={this.zoomOut}
-                                  recenterCanvas={this.recenterCanvas}
-                                  activeToolName={this.getActiveTool().name}
-                                  setActiveTool={this.setActiveTool}
-                                  previewPlaying={this.state.previewPlaying}
-                                  togglePreviewPlaying={this.togglePreviewPlaying}
+                                  importFileAsAsset={this.importFileAsAsset}
                                 />
                               </DockedPanel>
                             </ReflexElement>
+
                             <ReflexSplitter {...this.resizeProps}/>
-                            {/*Timeline*/}
+
+                            {/* Asset Library */}
                             <ReflexElement
                               minSize={100}
-                              size={this.state.timelineSize}
+                              size={this.state.assetLibrarySize}
                               onResize={this.resizeProps.onResize}
-                              onStopResize={this.resizeProps.onStopTimelineResize}>
-                              <DockedPanel  showOverlay={this.state.previewPlaying}>
-                                <Timeline
-                                  project={this.project}
-                                  projectDidChange={this.projectDidChange}
+                              onStopResize={this.resizeProps.onStopAssetLibraryResize}>
+                              <DockedPanel showOverlay={this.state.previewPlaying}>
+                                <AssetLibrary
                                   projectData={this.state.project}
-                                  getSelectedTimelineObjects={this.getSelectedTimelineObjects}
-                                  setOnionSkinOptions={this.setOnionSkinOptions}
-                                  getOnionSkinOptions={this.getOnionSkinOptions}
-                                  setFocusObject={this.setFocusObject}
-                                  addTweenKeyframe={this.addTweenKeyframe}
-                                  onRef={ref => this.timelineComponent = ref}
-                                  dragSoundOntoTimeline={this.dragSoundOntoTimeline}
+                                  assets={this.project.getAssets()}
+                                  openImportAssetFileDialog={this.openImportAssetFileDialog}
+                                  selectObjects={this.selectObjects}
+                                  clearSelection={this.clearSelection}
+                                  isObjectSelected={this.isObjectSelected}
                                 />
                               </DockedPanel>
                             </ReflexElement>
                           </ReflexContainer>
-                        </div>
-                      </ReflexElement>
-
-                      <ReflexSplitter {...this.resizeProps}/>
-
-                      {/* Right Sidebar */}
-                      <ReflexElement
-                        size={250}
-                        maxSize={300} minSize={200}
-                        onResize={this.resizeProps.onResize}
-                        onStopResize={this.resizeProps.onStopInspectorResize}>
-                        <ReflexContainer windowResizeAware={true} orientation="horizontal">
-                          {/* Inspector */}
-                          <ReflexElement {...this.resizeProps}>
-                            <DockedPanel showOverlay={this.state.previewPlaying}>
-                              <Inspector
-                                getToolSetting={this.getToolSetting}
-                                setToolSetting={this.setToolSetting}
-                                getSelectionType={this.getSelectionType}
-                                getAllSoundAssets={this.getAllSoundAssets}
-                                getAllSelectionAttributes={this.getAllSelectionAttributes}
-                                setSelectionAttribute={this.setSelectionAttribute}
-                                editorActions={this.actionMapInterface.editorActions}
-                                selectionIsScriptable={this.selectionIsScriptable}
-                                script={this.getSelectedObjectScript()}
-                                scriptInfoInterface={this.scriptInfoInterface}
-                                deleteScript={this.deleteScript}
-                                editScript={this.editScript}
-                                fontInfoInterface={this.fontInfoInterface}
-                                project={this.project}
-                                importFileAsAsset={this.importFileAsAsset}
-                              />
-                            </DockedPanel>
-                          </ReflexElement>
-
-                          <ReflexSplitter {...this.resizeProps}/>
-
-                          {/* Asset Library */}
-                          <ReflexElement
-                            minSize={100}
-                            size={this.state.assetLibrarySize}
-                            onResize={this.resizeProps.onResize}
-                            onStopResize={this.resizeProps.onStopAssetLibraryResize}>
-                            <DockedPanel showOverlay={this.state.previewPlaying}>
-                              <AssetLibrary
-                                projectData={this.state.project}
-                                assets={this.project.getAssets()}
-                                openImportAssetFileDialog={this.openImportAssetFileDialog}
-                                selectObjects={this.selectObjects}
-                                clearSelection={this.clearSelection}
-                                isObjectSelected={this.isObjectSelected}
-                              />
-                            </DockedPanel>
-                          </ReflexElement>
-                        </ReflexContainer>
-                      </ReflexElement>
-                    </ReflexContainer>
+                        </ReflexElement>
+                      </ReflexContainer>
+                    </div>
                   </div>
                 </div>
-              </div>
-          {this.state.codeEditorOpen &&
-            <PopOutCodeEditor
-              codeEditorWindowProperties={this.state.codeEditorWindowProperties}
-              updateCodeEditorWindowProperties={this.updateCodeEditorWindowProperties}
-              scriptInfoInterface={this.scriptInfoInterface}
-              selectionIsScriptable={this.selectionIsScriptable}
-              getSelectionType={this.getSelectionType}
-              script={this.getSelectedObjectScript()}
-              errors={this.state.codeErrors}
-              onMinorScriptUpdate={this.onMinorScriptUpdate}
-              onMajorScriptUpdate={this.onMajorScriptUpdate}
-              deleteScript={this.deleteScript}
-              scriptToEdit={this.state.scriptToEdit}
-              editScript={this.editScript}
-              toggleCodeEditor={this.toggleCodeEditor}
-              />}
+            {this.state.codeEditorOpen &&
+              <PopOutCodeEditor
+                codeEditorWindowProperties={this.state.codeEditorWindowProperties}
+                updateCodeEditorWindowProperties={this.updateCodeEditorWindowProperties}
+                scriptInfoInterface={this.scriptInfoInterface}
+                selectionIsScriptable={this.selectionIsScriptable}
+                getSelectionType={this.getSelectionType}
+                script={this.getSelectedObjectScript()}
+                errors={this.state.codeErrors}
+                onMinorScriptUpdate={this.onMinorScriptUpdate}
+                onMajorScriptUpdate={this.onMajorScriptUpdate}
+                deleteScript={this.deleteScript}
+                scriptToEdit={this.state.scriptToEdit}
+                editScript={this.editScript}
+                toggleCodeEditor={this.toggleCodeEditor}
+                />}
+          </div>
         </div>
-      </div>
-      )
+      </ErrorBoundary>
+    )
   }
 }
 

--- a/src/Editor/Editor.jsx
+++ b/src/Editor/Editor.jsx
@@ -51,6 +51,7 @@ import Toolbox from './Panels/Toolbox/Toolbox';
 import AssetLibrary from './Panels/AssetLibrary/AssetLibrary';
 import PopOutCodeEditor from './PopOuts/PopOutCodeEditor/PopOutCodeEditor';
 import ErrorBoundary from './Util/ErrorBoundary';
+import ErrorPage from './Util/ErrorPage';
 
 class Editor extends EditorCore {
   constructor () {
@@ -672,8 +673,8 @@ class Editor extends EditorCore {
 
     return (
       <ErrorBoundary
-        fallback={() => <div>Oops! Something broke</div>}
-        processError={(error, errorInfo)=> null /* save project here */ }
+        fallback={ErrorPage}
+        processError={(error, errorInfo) => null /* save project here */ }
         >
         <div>
           <div>

--- a/src/Editor/Util/ErrorBoundary/index.jsx
+++ b/src/Editor/Util/ErrorBoundary/index.jsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 WICKLETS LLC
+ *
+ * This file is part of Wick Editor.
+ *
+ * Wick Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Wick Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Wick Editor.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  state = {
+    hasError: false
+  }
+
+  static defaultProps = {
+    fallback: () => null
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    if(this.props.processError) {
+      this.props.processError(error, errorInfo)
+    }
+  }
+
+  render() {
+    if(this.state.hasError) {
+      const ErrorComponent = this.props.fallback;
+
+      return <ErrorComponent />;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/Editor/Util/ErrorPage/_index.scss
+++ b/src/Editor/Util/ErrorPage/_index.scss
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WICKLETS LLC
+ *
+ * This file is part of Wick Editor.
+ *
+ * Wick Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Wick Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Wick Editor.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+.error-page {
+  height: 100%;
+  background-color: #1EE29A;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  justify-content: center;
+}

--- a/src/Editor/Util/ErrorPage/index.jsx
+++ b/src/Editor/Util/ErrorPage/index.jsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WICKLETS LLC
+ *
+ * This file is part of Wick Editor.
+ *
+ * Wick Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Wick Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Wick Editor.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import './_index.scss';
+
+function ErrorPage() {
+  return (
+    <main class="error-page">
+      <h1> Oops! Something Broke!</h1>
+      <p>
+        Don't worry, we auto-saved your project! Please try refreshing while we
+        work get to work on a fix!
+      </p>
+    </main>
+  );
+}
+
+export default ErrorPage;


### PR DESCRIPTION
Best viewed with [whitespace diffs disabled](https://github.com/Wicklets/wick-editor/pull/25/files?w=1).

Introduce a generic error boundary component and wrap the editor in it. If anything beneath the editor breaks, this error boundary will catch and display the `ErrorPage` component it's passed:
<img width="931" alt="Screen Shot 2019-10-27 at 8 34 26 PM" src="https://user-images.githubusercontent.com/7584015/67644676-f0158c80-f8f9-11e9-92bf-42d1a22fe277.png">

I left a placeholder `processError` prop on the `ErrorBoundary` component in the `Editor` that can be used to add the appropriate logic to save the open project.

Feel free to use merge this PR, or use the code to further customize to what you guys need!