### PR TITLE
Add Support for Running in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node AS build
+
+RUN mkdir /wick
+
+WORKDIR /wick
+
+COPY package.json package-lock.json /wick/
+
+run npm install
+
+COPY .env CNAME CNAME_editor CNAME_test /wick/
+
+COPY src/ /wick/src/
+COPY public/ /wick/public/
+
+RUN ls src/
+
+RUN npm run build
+
+FROM httpd:2.4 AS deploy
+
+COPY --from=build /wick/build/ /usr/local/apache2/htdocs/


### PR DESCRIPTION
While it is a simple addition, it can be helpful in quickly running a self-hosted instance of Wick Editor in Docker. The included Dockerfile builds a production version of Wick, and hosts the static files using the Apache2 (httpd) Docker image.

If this addition is accepted, I would recommend a project admin set up a public repository on Docker Hub to automatically build a new image on each git push.

Great project by the way, I just found out about it today and wanted to get it running on Docker locally.

EDIT: Docker Hub example can be found here: https://hub.docker.com/r/alaskanpuffin/wick-editor