### PR TITLE
When adding asset, create frame if none exists

### DIFF
--- a/engine/dist/emptyproject.html
+++ b/engine/dist/emptyproject.html
@@ -14,7 +14,7 @@
         <!-- The Wick Engine build is injected here during the engine build step (see gulpfile.js) -->
         <script>
             /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2020.9.29.19.53.15";
+var WICK_ENGINE_BUILD_VERSION = "2020.11.18.9.31.13";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -50492,6 +50492,8 @@ Wick.Project = class extends Wick.Base {
 
 
   createImagePathFromAsset(asset, x, y, callback) {
+    let playheadPosition = this.focus.timeline.playheadPosition;
+    if (!this.activeFrame) this.activeLayer.insertBlankFrame(playheadPosition);
     asset.createInstance(path => {
       this.activeFrame.addPath(path);
       path.x = x;
@@ -50509,6 +50511,8 @@ Wick.Project = class extends Wick.Base {
 
 
   createClipInstanceFromAsset(asset, x, y, callback) {
+    let playheadPosition = this.focus.timeline.playheadPosition;
+    if (!this.activeFrame) this.activeLayer.insertBlankFrame(playheadPosition);
     asset.createInstance(clip => {
       this.activeFrame.addPath(clip);
       clip.x = x;
@@ -50526,6 +50530,8 @@ Wick.Project = class extends Wick.Base {
 
 
   createSVGInstanceFromAsset(asset, x, y, callback) {
+    let playheadPosition = this.focus.timeline.playheadPosition;
+    if (!this.activeFrame) this.activeLayer.insertBlankFrame(playheadPosition);
     asset.createInstance(svg => {
       this.addObject(svg);
       svg.x = x;

--- a/engine/dist/wickengine.js
+++ b/engine/dist/wickengine.js
@@ -1,5 +1,5 @@
 /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2020.9.29.19.53.15";
+var WICK_ENGINE_BUILD_VERSION = "2020.11.18.9.31.13";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -50477,6 +50477,8 @@ Wick.Project = class extends Wick.Base {
 
 
   createImagePathFromAsset(asset, x, y, callback) {
+    let playheadPosition = this.focus.timeline.playheadPosition;
+    if (!this.activeFrame) this.activeLayer.insertBlankFrame(playheadPosition);
     asset.createInstance(path => {
       this.activeFrame.addPath(path);
       path.x = x;
@@ -50494,6 +50496,8 @@ Wick.Project = class extends Wick.Base {
 
 
   createClipInstanceFromAsset(asset, x, y, callback) {
+    let playheadPosition = this.focus.timeline.playheadPosition;
+    if (!this.activeFrame) this.activeLayer.insertBlankFrame(playheadPosition);
     asset.createInstance(clip => {
       this.activeFrame.addPath(clip);
       clip.x = x;
@@ -50511,6 +50515,8 @@ Wick.Project = class extends Wick.Base {
 
 
   createSVGInstanceFromAsset(asset, x, y, callback) {
+    let playheadPosition = this.focus.timeline.playheadPosition;
+    if (!this.activeFrame) this.activeLayer.insertBlankFrame(playheadPosition);
     asset.createInstance(svg => {
       this.addObject(svg);
       svg.x = x;

--- a/engine/src/base/Project.js
+++ b/engine/src/base/Project.js
@@ -1038,7 +1038,7 @@ Wick.Project = class extends Wick.Base {
             });
         });
     }
-
+    
     /**
      * Adds an image path to the active frame using a given asset as its image src.
      * @param {Wick.Asset} asset - the asset to use for the image src
@@ -1047,6 +1047,9 @@ Wick.Project = class extends Wick.Base {
      * @param {function} callback - the function to call after the path is created.
      */
     createImagePathFromAsset(asset, x, y, callback) {
+		let playheadPosition = this.focus.timeline.playheadPosition;
+		if (!this.activeFrame)
+			this.activeLayer.insertBlankFrame(playheadPosition);
         asset.createInstance(path => {
             this.activeFrame.addPath(path);
             path.x = x;
@@ -1063,6 +1066,9 @@ Wick.Project = class extends Wick.Base {
      * @param {function} callback - the function to call after the path is created.
      */
     createClipInstanceFromAsset(asset, x, y, callback) {
+		let playheadPosition = this.focus.timeline.playheadPosition;
+		if (!this.activeFrame)
+			this.activeLayer.insertBlankFrame(playheadPosition);
         asset.createInstance(clip => {
             this.activeFrame.addPath(clip);
             clip.x = x;
@@ -1079,6 +1085,9 @@ Wick.Project = class extends Wick.Base {
      * @param {function} callback - the function to call after the path is created.
      */
     createSVGInstanceFromAsset(asset, x, y, callback) {
+		let playheadPosition = this.focus.timeline.playheadPosition;
+		if (!this.activeFrame)
+			this.activeLayer.insertBlankFrame(playheadPosition);
         asset.createInstance(svg => {
             this.addObject(svg);
             svg.x = x;

--- a/public/corelibs/wick-engine/emptyproject.html
+++ b/public/corelibs/wick-engine/emptyproject.html
@@ -14,7 +14,7 @@
         <!-- The Wick Engine build is injected here during the engine build step (see gulpfile.js) -->
         <script>
             /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2020.9.29.19.53.15";
+var WICK_ENGINE_BUILD_VERSION = "2020.11.18.9.31.13";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -50492,6 +50492,8 @@ Wick.Project = class extends Wick.Base {
 
 
   createImagePathFromAsset(asset, x, y, callback) {
+    let playheadPosition = this.focus.timeline.playheadPosition;
+    if (!this.activeFrame) this.activeLayer.insertBlankFrame(playheadPosition);
     asset.createInstance(path => {
       this.activeFrame.addPath(path);
       path.x = x;
@@ -50509,6 +50511,8 @@ Wick.Project = class extends Wick.Base {
 
 
   createClipInstanceFromAsset(asset, x, y, callback) {
+    let playheadPosition = this.focus.timeline.playheadPosition;
+    if (!this.activeFrame) this.activeLayer.insertBlankFrame(playheadPosition);
     asset.createInstance(clip => {
       this.activeFrame.addPath(clip);
       clip.x = x;
@@ -50526,6 +50530,8 @@ Wick.Project = class extends Wick.Base {
 
 
   createSVGInstanceFromAsset(asset, x, y, callback) {
+    let playheadPosition = this.focus.timeline.playheadPosition;
+    if (!this.activeFrame) this.activeLayer.insertBlankFrame(playheadPosition);
     asset.createInstance(svg => {
       this.addObject(svg);
       svg.x = x;

--- a/public/corelibs/wick-engine/wickengine.js
+++ b/public/corelibs/wick-engine/wickengine.js
@@ -1,5 +1,5 @@
 /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2020.9.29.19.53.15";
+var WICK_ENGINE_BUILD_VERSION = "2020.11.18.9.31.13";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -50477,6 +50477,8 @@ Wick.Project = class extends Wick.Base {
 
 
   createImagePathFromAsset(asset, x, y, callback) {
+    let playheadPosition = this.focus.timeline.playheadPosition;
+    if (!this.activeFrame) this.activeLayer.insertBlankFrame(playheadPosition);
     asset.createInstance(path => {
       this.activeFrame.addPath(path);
       path.x = x;
@@ -50494,6 +50496,8 @@ Wick.Project = class extends Wick.Base {
 
 
   createClipInstanceFromAsset(asset, x, y, callback) {
+    let playheadPosition = this.focus.timeline.playheadPosition;
+    if (!this.activeFrame) this.activeLayer.insertBlankFrame(playheadPosition);
     asset.createInstance(clip => {
       this.activeFrame.addPath(clip);
       clip.x = x;
@@ -50511,6 +50515,8 @@ Wick.Project = class extends Wick.Base {
 
 
   createSVGInstanceFromAsset(asset, x, y, callback) {
+    let playheadPosition = this.focus.timeline.playheadPosition;
+    if (!this.activeFrame) this.activeLayer.insertBlankFrame(playheadPosition);
     asset.createInstance(svg => {
       this.addObject(svg);
       svg.x = x;

--- a/src/Editor/EditorCore.jsx
+++ b/src/Editor/EditorCore.jsx
@@ -818,7 +818,7 @@ class EditorCore extends Component {
       this.project.createSVGInstanceFromAsset(window.Wick.ObjectCache.getObjectByUUID(uuid), dropPoint.x, dropPoint.y, svg => {
         this.projectDidChange({ actionName: "Create SVG Instance From Asset"});
       });
-    }else {
+    } else {
       console.error('object is not an ImageAsset or a ClipAsset')
     }
   }


### PR DESCRIPTION
When an instance of an asset is created and added to a project, it now
creates a frame on the current playhead position if none exists.

Also fixed a small formatting thing in EditorCore.jsx.

This should resolve issue #46.