### PR TITLE
Fix zooming with zoom box

### DIFF
--- a/engine/dist/emptyproject.html
+++ b/engine/dist/emptyproject.html
@@ -14,7 +14,7 @@
         <!-- The Wick Engine build is injected here during the engine build step (see gulpfile.js) -->
         <script>
             /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2020.9.29.19.53.15";
+var WICK_ENGINE_BUILD_VERSION = "2020.11.18.14.42.43";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -59658,8 +59658,9 @@ Wick.Tools.Zoom = class extends Wick.Tool {
   onMouseUp(e) {
     if (this.zoomBox && this.zoomBoxIsValidSize()) {
       var bounds = this.zoomBox.bounds;
+      var viewBounds = this.paper.view.bounds;
       this.paper.view.center = bounds.center;
-      this.paper.view.zoom = this.paper.view.bounds.height / bounds.height;
+      this.paper.view.scale(Math.min(viewBounds.height / bounds.height, viewBounds.width / bounds.width));
     } else {
       var zoomAmount = e.modifiers.alt ? this.ZOOM_OUT_AMOUNT : this.ZOOM_IN_AMOUNT;
       this.paper.view.scale(zoomAmount, e.point);

--- a/engine/dist/wickengine.js
+++ b/engine/dist/wickengine.js
@@ -1,5 +1,5 @@
 /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2020.9.29.19.53.15";
+var WICK_ENGINE_BUILD_VERSION = "2020.11.18.14.42.43";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -59643,8 +59643,9 @@ Wick.Tools.Zoom = class extends Wick.Tool {
   onMouseUp(e) {
     if (this.zoomBox && this.zoomBoxIsValidSize()) {
       var bounds = this.zoomBox.bounds;
+      var viewBounds = this.paper.view.bounds;
       this.paper.view.center = bounds.center;
-      this.paper.view.zoom = this.paper.view.bounds.height / bounds.height;
+      this.paper.view.scale(Math.min(viewBounds.height / bounds.height, viewBounds.width / bounds.width));
     } else {
       var zoomAmount = e.modifiers.alt ? this.ZOOM_OUT_AMOUNT : this.ZOOM_IN_AMOUNT;
       this.paper.view.scale(zoomAmount, e.point);

--- a/engine/src/tools/Zoom.js
+++ b/engine/src/tools/Zoom.js
@@ -66,8 +66,12 @@ Wick.Tools.Zoom = class extends Wick.Tool {
     onMouseUp (e) {
         if(this.zoomBox && this.zoomBoxIsValidSize()) {
             var bounds = this.zoomBox.bounds;
+            var viewBounds = this.paper.view.bounds;
             this.paper.view.center = bounds.center;
-            this.paper.view.zoom = this.paper.view.bounds.height / bounds.height;
+            this.paper.view.scale(Math.min(
+                viewBounds.height / bounds.height,
+                viewBounds.width / bounds.width
+            ));
         } else {
             var zoomAmount = e.modifiers.alt ? this.ZOOM_OUT_AMOUNT : this.ZOOM_IN_AMOUNT;
             this.paper.view.scale(zoomAmount, e.point);

--- a/public/corelibs/wick-engine/emptyproject.html
+++ b/public/corelibs/wick-engine/emptyproject.html
@@ -14,7 +14,7 @@
         <!-- The Wick Engine build is injected here during the engine build step (see gulpfile.js) -->
         <script>
             /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2020.9.29.19.53.15";
+var WICK_ENGINE_BUILD_VERSION = "2020.11.18.14.42.43";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -59658,8 +59658,9 @@ Wick.Tools.Zoom = class extends Wick.Tool {
   onMouseUp(e) {
     if (this.zoomBox && this.zoomBoxIsValidSize()) {
       var bounds = this.zoomBox.bounds;
+      var viewBounds = this.paper.view.bounds;
       this.paper.view.center = bounds.center;
-      this.paper.view.zoom = this.paper.view.bounds.height / bounds.height;
+      this.paper.view.scale(Math.min(viewBounds.height / bounds.height, viewBounds.width / bounds.width));
     } else {
       var zoomAmount = e.modifiers.alt ? this.ZOOM_OUT_AMOUNT : this.ZOOM_IN_AMOUNT;
       this.paper.view.scale(zoomAmount, e.point);

--- a/public/corelibs/wick-engine/wickengine.js
+++ b/public/corelibs/wick-engine/wickengine.js
@@ -1,5 +1,5 @@
 /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2020.9.29.19.53.15";
+var WICK_ENGINE_BUILD_VERSION = "2020.11.18.14.42.43";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/
@@ -59643,8 +59643,9 @@ Wick.Tools.Zoom = class extends Wick.Tool {
   onMouseUp(e) {
     if (this.zoomBox && this.zoomBoxIsValidSize()) {
       var bounds = this.zoomBox.bounds;
+      var viewBounds = this.paper.view.bounds;
       this.paper.view.center = bounds.center;
-      this.paper.view.zoom = this.paper.view.bounds.height / bounds.height;
+      this.paper.view.scale(Math.min(viewBounds.height / bounds.height, viewBounds.width / bounds.width));
     } else {
       var zoomAmount = e.modifiers.alt ? this.ZOOM_OUT_AMOUNT : this.ZOOM_IN_AMOUNT;
       this.paper.view.scale(zoomAmount, e.point);


### PR DESCRIPTION
Zooming using the zoom box now works as expected. Drawing a box with the
zoom box causes the screen to zoom to where the edges of the box would
be.

Zooming is still a little confusing when zoomed in because there is a
zoom limit, and the zoom box does not zoom past the zoom limit. I think
it makes sense to keep the zoom limit, it's just something to be aware
of.

Fixes issue #59.