### PR TITLE
Remove preloader on load

### DIFF
--- a/engine/dist/emptyproject.html
+++ b/engine/dist/emptyproject.html
@@ -14,7 +14,7 @@
         <!-- The Wick Engine build is injected here during the engine build step (see gulpfile.js) -->
         <script>
             /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2020.9.29.19.53.15";
+var WICK_ENGINE_BUILD_VERSION = "2020.12.2.14.57.28";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/

--- a/engine/dist/index.html
+++ b/engine/dist/index.html
@@ -27,6 +27,7 @@
                         .then(blob => {
                             // Hide preloader
                             document.getElementById('preloader').style.display = 'none';
+                            document.getElementById('preloader').remove();
                             // Run project
                             Wick.WickFile.fromWickFile(blob, project => {
                                 project.inject(document.getElementById('wick-canvas-container'));

--- a/engine/dist/wickengine.js
+++ b/engine/dist/wickengine.js
@@ -1,5 +1,5 @@
 /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2020.9.29.19.53.15";
+var WICK_ENGINE_BUILD_VERSION = "2020.12.2.14.57.28";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/

--- a/engine/src/export/zip/index.html
+++ b/engine/src/export/zip/index.html
@@ -27,6 +27,7 @@
                         .then(blob => {
                             // Hide preloader
                             document.getElementById('preloader').style.display = 'none';
+                            document.getElementById('preloader').remove();
                             // Run project
                             Wick.WickFile.fromWickFile(blob, project => {
                                 project.inject(document.getElementById('wick-canvas-container'));

--- a/public/corelibs/wick-engine/emptyproject.html
+++ b/public/corelibs/wick-engine/emptyproject.html
@@ -14,7 +14,7 @@
         <!-- The Wick Engine build is injected here during the engine build step (see gulpfile.js) -->
         <script>
             /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2020.9.29.19.53.15";
+var WICK_ENGINE_BUILD_VERSION = "2020.12.2.14.57.28";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/

--- a/public/corelibs/wick-engine/index.html
+++ b/public/corelibs/wick-engine/index.html
@@ -27,6 +27,7 @@
                         .then(blob => {
                             // Hide preloader
                             document.getElementById('preloader').style.display = 'none';
+                            document.getElementById('preloader').remove();
                             // Run project
                             Wick.WickFile.fromWickFile(blob, project => {
                                 project.inject(document.getElementById('wick-canvas-container'));

--- a/public/corelibs/wick-engine/wickengine.js
+++ b/public/corelibs/wick-engine/wickengine.js
@@ -1,5 +1,5 @@
 /*Wick Engine https://github.com/Wicklets/wick-engine*/
-var WICK_ENGINE_BUILD_VERSION = "2020.9.29.19.53.15";
+var WICK_ENGINE_BUILD_VERSION = "2020.12.2.14.57.28";
 /*!
  * Paper.js v0.12.4 - The Swiss Army Knife of Vector Graphics Scripting.
  * http://paperjs.org/

--- a/src/Editor/Editor.jsx
+++ b/src/Editor/Editor.jsx
@@ -327,6 +327,7 @@ class Editor extends EditorCore {
       this.recenterCanvas(); // Recenter the canvas after reload;
       setTimeout(() => {
         preloader.style.display = 'none';
+        preloader.remove();
       }, 500);
       this.project.view.render()
     }, 2000); // Wait two seconds to allow editor to set up... TODO: Should connect this to load events.


### PR DESCRIPTION
The preloader now gets removed from DOM after the editor or a project is done loading.