### PR TITLE
Show dropdowns on top of everything else

### DIFF
--- a/src/Editor/Util/WickInput/WickInput.jsx
+++ b/src/Editor/Util/WickInput/WickInput.jsx
@@ -224,6 +224,8 @@ class WickInput extends Component {
         options={this.props.options}
         className={classNames("wick-input-select", this.props.className)}
         classNamePrefix={'wick-input-select'}
+        menuPortalTarget={document.body}
+        menuPosition={'fixed'}
         styles={{
         option: (provided, state) => {
           let style = {


### PR DESCRIPTION
Dropdowns should now be shown on top of everything else, as expected.

https://github.com/JedWatson/react-select/issues/1010#issuecomment-732314182