### PR TITLE
Allow selecting alpha in background for project

### DIFF
--- a/src/Editor/Modals/SettingsModal/ProjectSettings/ProjectSettings.jsx
+++ b/src/Editor/Modals/SettingsModal/ProjectSettings/ProjectSettings.jsx
@@ -280,7 +280,7 @@ class ProjectSettings extends Component {
           <WickInput
             type="color"
             id="project-background-color-picker"
-            disableAlpha={true}
+            disableAlpha={false}
             placement={'bottom'}
             color={this.state.backgroundColor}
             onChange={this.changeProjectBackgroundColor}


### PR DESCRIPTION
This PR allows the user to specify an alpha value for the project background color setting.

Allowing the project background to be transparent would be useful for those who use Wick Editor to create parts of an animation to be incorporated later into other programs. Adobe Flash did not allow selecting a transparent background color, however the color was only used for export options that required a background like video, while the png sequence option used a transparent background. This is not the case for Wick Editor. After applying this change, all of the export options still work, with the video and gif export defaulting to a black background.
