### PR TITLE
resolution for bug 311 on github

### DIFF
--- a/src/Editor/Editor.jsx
+++ b/src/Editor/Editor.jsx
@@ -863,6 +863,11 @@ class Editor extends EditorCore {
 
   handleAssetFileImport = (e) => {
     this.createAssets(e.target.files, []);
+    //resetting event so onchange can fire again
+    //this was causing bug reported via bug 311 on github
+    //this issue will happen even if you don't delete and try to reload the file
+    e.target.value="";
+    //end for bug id 311
   }
 
   openProjectFileDialog = () => {


### PR DESCRIPTION
The issue was coming when user is trying to upload the same file again , the method that is used to open file dialog is using onchange, since nothing changes i.e. the file name remains same ( even if you delete it) this was not uploading the file again. Cleared the event params to envoke the event again.
Resolution for bug 311 reported on github.

Thanks
Vivek